### PR TITLE
Add specs for new method patch_json

### DIFF
--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -35,20 +35,6 @@ module Hubspot
         handle_response(response)
       end
 
-      def patch_json(path, options)
-        url = generate_url(path, options[:params])
-
-        response = patch(
-          url,
-          body: options[:body].to_json,
-          headers: { "Content-Type" => "application/json" },
-          format: :json
-        )
-
-        log_request_and_response(url, response, options[:body])
-        handle_response(response)
-      end
-
       def delete_json(path, opts)
         url = generate_url(path, opts)
         response = delete(url, format: :json)

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -35,6 +35,20 @@ module Hubspot
         handle_response(response)
       end
 
+      def patch_json(path, options)
+        url = generate_url(path, options[:params])
+
+        response = patch(
+          url,
+          body: options[:body].to_json,
+          headers: { "Content-Type" => "application/json" },
+          format: :json
+        )
+
+        log_request_and_response(url, response, options[:body])
+        handle_response(response)
+      end
+
       def delete_json(path, opts)
         url = generate_url(path, opts)
         response = delete(url, format: :json)

--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -127,6 +127,21 @@ module Hubspot
         end
       end
 
+      def find_by_email!(emails)
+        batch_mode, path, params = case emails
+        when String then [false, GET_CONTACT_BY_EMAIL_PATH, { contact_email: emails }]
+        when Array then [true, GET_CONTACTS_BY_EMAIL_PATH, { batch_email: emails }]
+        else raise Hubspot::InvalidParams, 'expecting String or Array of Strings parameter'
+        end
+
+        response = Hubspot::Connection.get_json(path, params)
+        if batch_mode
+          response.map{|_, contact| new(contact)}
+        else
+          new(response)
+        end
+      end
+
       # NOTE: problem with batch api endpoint
       # {https://developers.hubspot.com/docs/methods/contacts/get_contact_by_utk}
       # {https://developers.hubspot.com/docs/methods/contacts/get_batch_by_utk}

--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -93,14 +93,14 @@ module Hubspot
       # NOTE: problem with batch api endpoint
       # {https://developers.hubspot.com/docs/methods/contacts/get_contact}
       # {https://developers.hubspot.com/docs/methods/contacts/get_batch_by_vid}
-      def find_by_id(vids)
+      def find_by_id(vids, opts = {})
         batch_mode, path, params = case vids
         when Integer then [false, GET_CONTACT_BY_ID_PATH, { contact_id: vids }]
         when Array then [true, CONTACT_BATCH_PATH, { batch_vid: vids }]
         else raise Hubspot::InvalidParams, 'expecting Integer or Array of Integers parameter'
         end
 
-        response = Hubspot::Connection.get_json(path, params)
+        response = Hubspot::Connection.get_json(path, params.merge(includePropertyVersions: opts[:include_property_versions]))
         raise Hubspot::ApiError if batch_mode
         new(response)
       end
@@ -182,6 +182,7 @@ module Hubspot
 
     attr_reader :properties, :vid, :is_new
     attr_reader :is_contact, :list_memberships
+    attr_reader :properties_unformatted
 
     def initialize(response_hash)
       props = response_hash['properties']
@@ -189,6 +190,7 @@ module Hubspot
       @is_contact = response_hash["is-contact"]
       @list_memberships = response_hash["list-memberships"] || []
       @vid = response_hash['vid']
+      @properties_unformatted = response_hash["properties"]
     end
 
     def [](property)

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -126,7 +126,7 @@ module Hubspot
         metadata: params[:metadata]         || metadata
       }
 
-      Hubspot::Connection.patch_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
+      Hubspot::Connection.put_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
       self
     end
   end

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -126,7 +126,7 @@ module Hubspot
         metadata: params[:metadata]         || metadata
       }
 
-      Hubspot::Connection.put_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
+      Hubspot::Connection.patch_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
       self
     end
   end

--- a/spec/lib/hubspot/connection_spec.rb
+++ b/spec/lib/hubspot/connection_spec.rb
@@ -97,6 +97,79 @@ describe Hubspot::Connection do
     end
   end
 
+  describe ".patch_json" do
+    let(:metadata) do
+      {
+        metadata:
+          {
+            title: "Démo groupée",
+            body: "https://fake_link.com",
+          }
+      }
+    end
+    let(:response_metadata) do
+      {
+        "metadata" =>
+          {
+            "title" => "Démo groupée",
+            "body" => "https://fake_link.com",
+          }
+      }
+    end
+
+    it "issues a PATCH request and returns the parsed body" do
+      path = "/some/path"
+      update_options = { params: {}, body: metadata }
+      
+
+      stub_request(:patch, "https://api.hubapi.com/some/path?hapikey=fake").
+        to_return(status: 200, body: JSON.generate(metadata))
+
+      response = Hubspot::Connection.patch_json(path, update_options)
+
+      assert_requested(
+        :patch,
+        "https://api.hubapi.com/some/path?hapikey=fake",
+         {
+           body: metadata.to_json,
+           headers: { "Content-Type" => "application/json" },
+         }
+      )
+
+      expect(response).to eq(response_metadata)
+    end
+
+    it "logs information about the request and response" do
+      path = "/some/path"
+      update_options = { params: {}, body: metadata }
+
+      logger = stub_logger
+
+      stub_request(:patch, "https://api.hubapi.com/some/path?hapikey=fake").
+        to_return(status: 200, body: JSON.generate(metadata))
+
+      Hubspot::Connection.patch_json(path, update_options)
+
+      expect(logger).to have_received(:info).with(<<~MSG)
+        Hubspot: https://api.hubapi.com/some/path?hapikey=fake.
+        Body: #{metadata}.
+        Response: 200 #{metadata.to_json}
+      MSG
+    end
+
+    it "raises when the request fails" do
+      path = "/some/path"
+      update_options = { params: {}, body: {} }
+
+      stub_request(:patch, "https://api.hubapi.com/some/path?hapikey=fake").
+        to_return(status: 401)
+
+      expect {
+        Hubspot::Connection.patch_json(path, update_options)
+      }.to raise_error(Hubspot::RequestError)
+    end
+  end
+
   context 'private methods' do
     describe ".generate_url" do
       let(:path){ "/test/:email/profile" }


### PR DESCRIPTION
Add specs for new method patch_json
I followed the same pattern used for the other specs in this file with the Webmock syntax.

Notion card: [https://www.notion.so/matera/BACK-Add-specs-for-patch_json-in-hubspot-ruby-b88396c7dbf1432cbce6e8defd42cc10](url)